### PR TITLE
remove cast from int to int, remove subscript

### DIFF
--- a/laurel/__init__.py
+++ b/laurel/__init__.py
@@ -97,7 +97,7 @@ class laurel:
             properties = get_properties(self.auth, mesh['product_id'],
                                         mesh['id'])
             for bulb in properties['bulbsArray']:
-                id = int(bulb['deviceID'][-3:])
+                id = bulb['deviceID']
                 mac = [bulb['mac'][i:i+2] for i in range(0, 12, 2)]
                 mac = "%s:%s:%s:%s:%s:%s" % (mac[5], mac[4], mac[3], mac[2], mac[1], mac[0])
                 if network is None:


### PR DESCRIPTION
In my initial use of this project I found this issue:
```
Traceback (most recent call last):
  File "laurel-test.py", line 4, in <module>
    devices = laurel.laurel(os.getenv("C_BY_GE_USERNAME"), os.getenv("C_BY_GE_PASSWORD"))
  File "/home/trevor/Documents/python/discord-bot/.venv/lib/python3.7/site-packages/laurel/__init__.py", line 100, in __init__
    id = int(bulb['deviceID'][-3:])
TypeError: 'int' object is not subscriptable
```

I found that the 'deviceID' key in 'properties' already had an `int` value. I have removed the subscripting and the now-redundant cast to `int`.